### PR TITLE
feat & change :  permission API and field change in event detail dto

### DIFF
--- a/src/main/java/com/skku/skkuduler/application/PermissionService.java
+++ b/src/main/java/com/skku/skkuduler/application/PermissionService.java
@@ -4,8 +4,10 @@ import com.skku.skkuduler.common.exception.Error;
 import com.skku.skkuduler.common.exception.ErrorException;
 import com.skku.skkuduler.domain.calender.Event;
 import com.skku.skkuduler.domain.user.User;
+import com.skku.skkuduler.dto.response.DepartmentPermissionDto;
 import com.skku.skkuduler.infrastructure.EventRepository;
 import com.skku.skkuduler.infrastructure.UserRepository;
+import com.skku.skkuduler.presentation.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +29,9 @@ public class PermissionService {
         User user = userRepository.findByIdFetchPermissions(userId).orElseThrow(()-> new ErrorException(Error.USER_NOT_FOUND));
         Event event = eventRepository.findById(eventId).orElseThrow(()-> new ErrorException(Error.EVENT_NOT_FOUND));
         return user.hasPermission(event.getDepartmentId());
+    }
+
+    public DepartmentPermissionDto getDepartmentPermissions(Long userId) {
+        return userRepository.getDepartmentPermissionDto(userId);
     }
 }

--- a/src/main/java/com/skku/skkuduler/dto/response/CalendarEventDetailDto.java
+++ b/src/main/java/com/skku/skkuduler/dto/response/CalendarEventDetailDto.java
@@ -20,7 +20,7 @@ public class CalendarEventDetailDto {
     private LocalDateTime createdAt;
     private Boolean isDepartmentEvent;
     private Boolean isCommonEvent;
-    private Boolean isMyEvent;
+    private Boolean hasPermission;
     private Boolean isAddedToMyCalendar;
     private Long ownerUserId;
     private String ownerName;

--- a/src/main/java/com/skku/skkuduler/dto/response/DepartmentPermissionDto.java
+++ b/src/main/java/com/skku/skkuduler/dto/response/DepartmentPermissionDto.java
@@ -1,0 +1,22 @@
+package com.skku.skkuduler.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DepartmentPermissionDto {
+    private List<PermissionInfo> permissions;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PermissionInfo{
+        private Long departmentId;
+        private String departmentName;
+    }
+}

--- a/src/main/java/com/skku/skkuduler/infrastructure/UserRepository.java
+++ b/src/main/java/com/skku/skkuduler/infrastructure/UserRepository.java
@@ -1,7 +1,9 @@
 package com.skku.skkuduler.infrastructure;
 
 import com.skku.skkuduler.domain.user.User;
+import com.skku.skkuduler.dto.response.DepartmentPermissionDto;
 import com.skku.skkuduler.dto.response.UserProfileDto;
+import com.skku.skkuduler.infrastructure.querydsl.UserCustomRepository;
 import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +14,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
 
     @Query("""
     SELECT DISTINCT u
@@ -71,4 +73,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     WHERE u.userId = :userId AND u.deletedAt IS NULL
     """)
     Optional<UserProfileDto> getUserProfileDto(@Param("userId") Long userId, @Param("viewerId") Long viewerId);
+
 }

--- a/src/main/java/com/skku/skkuduler/infrastructure/querydsl/UserCustomRepository.java
+++ b/src/main/java/com/skku/skkuduler/infrastructure/querydsl/UserCustomRepository.java
@@ -1,0 +1,8 @@
+package com.skku.skkuduler.infrastructure.querydsl;
+
+import com.skku.skkuduler.dto.response.DepartmentPermissionDto;
+import org.springframework.data.repository.query.Param;
+
+public interface UserCustomRepository {
+    DepartmentPermissionDto getDepartmentPermissionDto(@Param("userId") Long userId);
+}

--- a/src/main/java/com/skku/skkuduler/infrastructure/querydsl/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/skku/skkuduler/infrastructure/querydsl/UserCustomRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.skku.skkuduler.infrastructure.querydsl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.skku.skkuduler.domain.department.QDepartment;
+import com.skku.skkuduler.domain.user.QPermission;
+import com.skku.skkuduler.domain.user.QUser;
+import com.skku.skkuduler.dto.response.DepartmentPermissionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.w3c.dom.stylesheets.LinkStyle;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public DepartmentPermissionDto getDepartmentPermissionDto(Long userId) {
+        QUser user = QUser.user;
+        QPermission permission = QPermission.permission;
+        QDepartment department = QDepartment.department;
+
+        List<DepartmentPermissionDto.PermissionInfo> permissions = jpaQueryFactory
+                .select(Projections.constructor(DepartmentPermissionDto.PermissionInfo.class,
+                        permission.departmentId,
+                        department.name
+                ))
+                .from(permission)
+                .join(permission.user, user).on(user.userId.eq(userId))
+                .join(department).on(department.departmentId.eq(permission.departmentId))
+                .fetch();
+
+        return new DepartmentPermissionDto(permissions);
+    }
+}

--- a/src/main/java/com/skku/skkuduler/presentation/endpoint/AdminEndpoint.java
+++ b/src/main/java/com/skku/skkuduler/presentation/endpoint/AdminEndpoint.java
@@ -8,6 +8,7 @@ import com.skku.skkuduler.common.security.JwtUtil;
 import com.skku.skkuduler.domain.user.User;
 import com.skku.skkuduler.dto.request.EventCreationDto;
 import com.skku.skkuduler.dto.request.EventUpdateDto;
+import com.skku.skkuduler.dto.response.DepartmentPermissionDto;
 import com.skku.skkuduler.presentation.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -27,44 +28,55 @@ public class AdminEndpoint {
                                                    EventCreationDto eventCreationDto,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
         Long userId = jwtUtil.extractUserId(token);
-        if(jwtUtil.extractRole(token) != User.Role.ADMIN){
+        if (jwtUtil.extractRole(token) != User.Role.ADMIN) {
             throw new ErrorException(Error.PERMISSION_DENIED);
         }
-        if(!permissionService.hasDepartmentPermission(userId,departmentId)){
+        if (!permissionService.hasDepartmentPermission(userId, departmentId)) {
             throw new ErrorException(Error.PERMISSION_DENIED);
         }
-        calendarService.createDepartmentCalendarEvent(departmentId,eventCreationDto);
+        calendarService.createDepartmentCalendarEvent(departmentId, eventCreationDto);
         return new ApiResponse<>("학과 일정이 성공적으로 생성되었습니다.");
 
     }
+
     // 학과 일정 수정
     @PutMapping("/departments/calendars/events/{eventId}")
     public ApiResponse<Void> updateDepartmentEvent(@PathVariable("eventId") Long eventId,
                                                    EventUpdateDto eventUpdateDto,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
         Long userId = jwtUtil.extractUserId(token);
-        if(jwtUtil.extractRole(token) != User.Role.ADMIN){
+        if (jwtUtil.extractRole(token) != User.Role.ADMIN) {
             throw new ErrorException(Error.PERMISSION_DENIED);
         }
-        if(!permissionService.hasEventPermission(userId, eventId)){
+        if (!permissionService.hasEventPermission(userId, eventId)) {
             throw new ErrorException(Error.PERMISSION_DENIED);
         }
-        calendarService.updateCalendarEvent(eventId,eventUpdateDto);
+        calendarService.updateCalendarEvent(eventId, eventUpdateDto);
         return new ApiResponse<>("학과 일정이 성공적으로 수정되었습니다.");
 
     }
+
     // 학과 일정 삭제
     @DeleteMapping("/departments/calendars/events/{eventId}")
     public ApiResponse<Void> deleteDepartmentEvent(@PathVariable("eventId") Long eventId,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
         Long userId = jwtUtil.extractUserId(token);
-        if(jwtUtil.extractRole(token) != User.Role.ADMIN){
+        if (jwtUtil.extractRole(token) != User.Role.ADMIN) {
             throw new ErrorException(Error.PERMISSION_DENIED);
         }
-        if(!permissionService.hasEventPermission(userId, eventId)){
+        if (!permissionService.hasEventPermission(userId, eventId)) {
             throw new ErrorException(Error.PERMISSION_DENIED);
         }
         calendarService.deleteDepartmentCalendarEvent(eventId);
         return new ApiResponse<>("학과 일정이 성공적으로 삭제되었습니다.");
+    }
+
+    @GetMapping("/permissions/departments")
+    public ApiResponse<DepartmentPermissionDto> getDepartmentPermissions(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+        Long userId = jwtUtil.extractUserId(token);
+        if (jwtUtil.extractRole(token) != User.Role.ADMIN) {
+            throw new ErrorException(Error.PERMISSION_DENIED);
+        }
+        return new ApiResponse<>(permissionService.getDepartmentPermissions(userId));
     }
 }

--- a/src/main/java/com/skku/skkuduler/presentation/endpoint/AdminEndpoint.java
+++ b/src/main/java/com/skku/skkuduler/presentation/endpoint/AdminEndpoint.java
@@ -22,7 +22,7 @@ public class AdminEndpoint {
     private final PermissionService permissionService;
 
     // 학과 일정 등록
-    @PostMapping("/departments/{departmentId}/events")
+    @PostMapping("/departments/{departmentId}/calendars/events")
     public ApiResponse<Void> createDepartmentEvent(@PathVariable("departmentId") Long departmentId,
                                                    EventCreationDto eventCreationDto,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
@@ -38,7 +38,7 @@ public class AdminEndpoint {
 
     }
     // 학과 일정 수정
-    @PutMapping("/departments/events/{eventId}")
+    @PutMapping("/departments/calendars/events/{eventId}")
     public ApiResponse<Void> updateDepartmentEvent(@PathVariable("eventId") Long eventId,
                                                    EventUpdateDto eventUpdateDto,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
@@ -54,7 +54,7 @@ public class AdminEndpoint {
 
     }
     // 학과 일정 삭제
-    @DeleteMapping("/departments/events/{eventId}")
+    @DeleteMapping("/departments/calendars/events/{eventId}")
     public ApiResponse<Void> deleteDepartmentEvent(@PathVariable("eventId") Long eventId,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
         Long userId = jwtUtil.extractUserId(token);


### PR DESCRIPTION
### feat
-  [GET] /api/admin/permissions/departments
- 현재 관리자가 권한을 부여받은(학과 달력 CRUD 가능) 학과 목록 반환

### change
- [GET] /api/users/calendars/events/{eventId}
- 반환필드중 isMyEvent를 hasPermission으로 변경
- 유저 일정일 경우 event.userId와 비교해서 일치하면 true or false
- 학과 일정일 겨웅 permission 테이블에 쿼리를 보내 event.departmentId와 속한 permission이있는지 체크후 true or false